### PR TITLE
DATA-717: upgrade airflow from 1.5.2 -> 1.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-airflow[mysql, celery, crypto, postgres, s3, slack]==1.5.2
+airflow[mysql, celery, crypto, postgres, s3, slack]==1.6.1
 boto==2.38.0
 iso3166==0.7
 mock==1.3.0


### PR DESCRIPTION
Incrementing airflow version from 1.5.2 to 1.6.1

Harsha tested basic computron functionality post upgrade.