### PR TITLE
DATA-719: Add sqlalchemy-redshift to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyMySQL==0.6.6
 pytest==2.8.2
 unicodecsv==0.9.0
 redis==2.10.5
+sqlalchemy-redshift==0.4.0


### PR DESCRIPTION
sqlalchemy-redshift allows us to to use SQLAlchemy's Redshift dialect to generate valid SQL to run against it using SQLAlchemy DDL structures.